### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,21 +6,21 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AmciLib		                   KEYWORD1
+AmciLib	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin						   KEYWORD2
-LogMode		                   KEYWORD2
-SetPosition                    KEYWORD2
+begin	KEYWORD2
+LogMode	KEYWORD2
+SetPosition	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-SERIAL_MODE 				   LITERAL1
-PWM_MODE	 				   LITERAL1
-ANALOG_MODE					   LITERAL1
-MAX_POSITION				   LITERAL1
-MIN_POSITION				   LITERAL1
+SERIAL_MODE	LITERAL1
+PWM_MODE	LITERAL1
+ANALOG_MODE	LITERAL1
+MAX_POSITION	LITERAL1
+MIN_POSITION	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords